### PR TITLE
MSM truncate

### DIFF
--- a/.github/ISSUE_TEMPLATE/audit_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/audit_ticket.yaml
@@ -5,7 +5,7 @@ body:
     id: crate
     attributes:
       label: Crate
-      description: What ragu crate is this related to?
+      description: Which Ragu crate is this related to?
       options:
         - ragu_arithmetic
         - ragu_circuits
@@ -18,26 +18,52 @@ body:
       default: 0
     validations:
       required: true
-  - type: textarea
-    id: current-behavior
+
+   - type: dropdown
+    id: severity
     attributes:
-      label: What is the current behavior and what is the issue with it?
-      description: A concise description of the issue with the Ragu code (if you describe a bug, include env details and steps to reproduce)
+      label: Severity
+      description: Select the issue severity.
+      options:
+        - "low"
+        - "medium"
+        - "high"
+        - "critical"
+      default: 0
     validations:
       required: true
+
   - type: textarea
-    id: expected-behavior
+    id: description
     attributes:
-      label: What is the expected behavior? How to fix the code?
-      description: A concise description of the fix
+      label: Description
+      description: A concise description of the issue in the Ragu code. If you describe a bug, include environment details and steps to reproduce.
     validations:
       required: true
-  - type: textarea
-    id: logs
+
+  - type: markdown
+    id: code
     attributes:
-      label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: shell
+      value: |
+        **Code**
+
+        Provide the relevant existing code and newly created tests to demonstrate the issue.
+
+        File name: `crates/ragu_circuits/src/mesh.rs`
+
+        ```rust
+        pub fn omega_j<F: PrimeField>(self) -> F {
+            let bit_reversal_id = bitreverse(self.0, F::S);
+            F::ROOT_OF_UNITY.pow([bit_reversal_id.into()])
+        }
+        ```
     validations:
       required: false
 
+  - type: textarea
+    id: recommendations
+    attributes:
+      label: Recommendations
+      description: Provide recommendations for resolution / remediation.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/audit_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/audit_ticket.yaml
@@ -1,0 +1,43 @@
+name: Ragu Audit Ticket
+description: Flag issues with Ragu as part of the QEDIT audit
+body:
+  - type: dropdown
+    id: crate
+    attributes:
+      label: Crate
+      description: What ragu crate is this related to?
+      options:
+        - ragu_arithmetic
+        - ragu_circuits
+        - ragu_core
+        - ragu_gadgets
+        - ragu_macros
+        - ragu_pasta
+        - ragu_pcd
+        - ragu_primitives
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: What is the current behavior and what is the issue with it?
+      description: A concise description of the issue with the Ragu code (if you describe a bug, include env details and steps to reproduce)
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: What is the expected behavior? How to fix the code?
+      description: A concise description of the fix
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/audit_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/audit_ticket.yaml
@@ -41,21 +41,21 @@ body:
     validations:
       required: true
 
-  - type: markdown
+  - type: textarea
     id: code
     attributes:
+      label: Code
+      description: Relevant code and any new tests that reproduce the issue.
+      render: shell
       value: |
-        **Code**
-
-        Provide the relevant existing code and newly created tests to demonstrate the issue.
-
-        File name: `crates/ragu_circuits/src/mesh.rs`
+        File name: `crates/.../src/...`
 
         ```rust
-        pub fn omega_j<F: PrimeField>(self) -> F {
-            let bit_reversal_id = bitreverse(self.0, F::S);
-            F::ROOT_OF_UNITY.pow([bit_reversal_id.into()])
-        }
+        // existing code
+        ```
+
+        ```rust
+        // new test(s) demonstrating the issue
         ```
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/audit_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/audit_ticket.yaml
@@ -46,16 +46,16 @@ body:
     attributes:
       label: Code
       description: Relevant code and any new tests that reproduce the issue.
-      render: shell
       value: |
-        File name: `crates/.../src/...`
+        File name: `...crates/ragu_circuits/src/mesh.rs...`
 
         ```rust
         // existing code
+          pub fn omega_j<F: PrimeField>(self) -> F {}
         ```
 
         ```rust
-        // new test(s) demonstrating the issue
+        // a new test to demonstrate the issue, if needed.
         ```
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/audit_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/audit_ticket.yaml
@@ -19,16 +19,16 @@ body:
     validations:
       required: true
 
-   - type: dropdown
+  - type: dropdown
     id: severity
     attributes:
       label: Severity
       description: Select the issue severity.
       options:
-        - "low"
-        - "medium"
-        - "high"
-        - "critical"
+        - low
+        - medium
+        - high
+        - critical
       default: 0
     validations:
       required: true

--- a/crates/ragu_arithmetic/tests/audit.rs
+++ b/crates/ragu_arithmetic/tests/audit.rs
@@ -1,8 +1,3 @@
-//! Security audit verification tests for ragu_arithmetic.
-//!
-//! Each test targets one specific finding from the audit, demonstrating
-//! the issue exists at the current code level.
-
 use pasta_curves::{
     Fp as F,
     group::{Curve, prime::PrimeCurveAffine},

--- a/crates/ragu_arithmetic/tests/audit.rs
+++ b/crates/ragu_arithmetic/tests/audit.rs
@@ -1,0 +1,47 @@
+//! Security audit verification tests for ragu_arithmetic.
+//!
+//! Each test targets one specific finding from the audit, demonstrating
+//! the issue exists at the current code level.
+
+use pasta_curves::{
+    Fp as F,
+    group::{Curve, prime::PrimeCurveAffine},
+};
+use ragu_arithmetic::{dot, mul};
+
+///  MSM `mul()` silently truncates on length mismatch
+///
+/// A caller passing mismatched-length vectors gets a wrong
+/// result with no error.
+#[test]
+fn msm_silent_truncation_on_length_mismatch() {
+    let bases: Vec<pasta_curves::EqAffine> = (1u64..=5)
+        .map(|i| (pasta_curves::EqAffine::generator() * F::from(i)).to_affine())
+        .collect();
+
+    // full 5element coefficient vector
+    let full_coeffs: Vec<F> = (1u64..=5).map(F::from).collect();
+
+    // 3element coefficient vector (caller mistake)
+    let short_coeffs: Vec<F> = (1u64..=3).map(F::from).collect();
+
+    // mul() with mismatched lengths: 3 coefficients, 5 bases
+    let result_short = mul(short_coeffs.iter(), bases.iter());
+
+    // compare against the correct full computation
+    let result_full = mul(full_coeffs.iter(), bases.iter());
+
+    // terms 4 and 5 were silently discarded
+    assert_ne!(
+        result_short, result_full,
+        "MSM silently dropped terms, wrong result with no error"
+    );
+
+    let did_panic = std::panic::catch_unwind(|| {
+        dot(short_coeffs.iter(), full_coeffs.iter());
+    });
+    assert!(
+        did_panic.is_err(),
+        "dot() correctly panics on length mismatch"
+    );
+}


### PR DESCRIPTION
MSM `mul()` silently truncates on length mismatch

A caller passing mismatched-length vectors gets a wrong result with no error.

described in https://github.com/QED-it/ragu/issues/1